### PR TITLE
Fixed dense-dense path for JCuda, also switched to JCublas2 interface

### DIFF
--- a/cuda/src/main/scala/org/apache/mahout/cuda/Context.scala
+++ b/cuda/src/main/scala/org/apache/mahout/cuda/Context.scala
@@ -25,23 +25,21 @@ import jcuda.runtime.JCuda
 
 import jcuda._
 import jcublas._
-import JCublas._
+import jcublas.JCublas2._
 
 final class Context {
   // Enable exceptions for all CUDA libraries
   JCuda.setExceptionsEnabled(true)
+  JCublas2.setExceptionsEnabled(true)
   JCusparse.setExceptionsEnabled(true)
 
   // Initialize JCusparse library and create a dense handle for it.
   var sparseHandle: jcuda.jcusparse.cusparseHandle = new cusparseHandle()
   cusparseCreate(sparseHandle)
 
-  // Initialize JCublas library and create a dense handle for it.
-  // // seems that there is no `dense handle` for JCublas
-  var denseHandle = JCublas.cublasInit()
-  //TODO: is this needed somehow- via the cusparse library?
-  // cusparseCreate(denseHandle)
-
+  // Initialize JCublas2 library and create a dense handle for it.
+  var denseHandle: jcuda.jcublas.cublasHandle = new cublasHandle()
+  cublasCreate(denseHandle)
 
 }
 

--- a/cuda/src/main/scala/org/apache/mahout/cuda/DenseRowMatrix.scala
+++ b/cuda/src/main/scala/org/apache/mahout/cuda/DenseRowMatrix.scala
@@ -60,14 +60,7 @@ final class DenseRowMatrix {
     context = ctx
 
     // allocate empty space on the GPU
-    cublasAlloc(nrows * ncols * jcuda.Sizeof.DOUBLE, jcuda.Sizeof.DOUBLE , vals)
-
-    // create and setup matrix descriptor
-    // Todo: do we want these? for dense %*% sparse?
-    // JCuda.cublasCreateMatDescr(descr)
-    // cublasSetMatType(descr, CUSPARSE_MATRIX_TYPE_GENERAL)
-    // cusparseSetMatIndexBase(descr, CUSPARSE_INDEX_BASE_ZERO)
-
+    cudaMalloc(vals, nrows * ncols * jcuda.Sizeof.DOUBLE)
   }
 
   /**
@@ -85,13 +78,7 @@ final class DenseRowMatrix {
     context = ctx
 
     // allocate empty space on the GPU
-    cublasAlloc(nrows * ncols * jcuda.Sizeof.DOUBLE, jcuda.Sizeof.DOUBLE, vals)
-
-    // create and setup matrix descriptor
-    // Todo: do we want these? for dense %*% sparse?
-    // cusblasCreateMatDescr(descr)
-    // cusblasSetMatType(descr, CUSPARSE_MATRIX_TYPE_GENERAL)
-    // cusparseSetMatIndexBase(descr, CUSPARSE_INDEX_BASE_ZERO)
+    cudaMalloc(vals, nrows * ncols * jcuda.Sizeof.DOUBLE)
 
     cudaMemcpy(vals, jcuda.Pointer.to(data.toList.flatten.toArray),
       (nrow) * (ncol) * jcuda.Sizeof.DOUBLE,
@@ -113,13 +100,6 @@ final class DenseRowMatrix {
     context = ctx
 
     vals = data
-
-    // create and setup matrix descriptor
-    // Todo: do we need these? for dense %*% sparse?
-    //cusblasCreateMatDescr(descr)
-    //cusblasSetMatType(descr, CUSPARSE_MATRIX_TYPE_GENERAL)
-    //cusparseSetMatIndexBase(descr, CUSPARSE_INDEX_BASE_ZERO)
-
   }
 
   /**Set values with an 2d Array
@@ -128,8 +108,8 @@ final class DenseRowMatrix {
     */
   def set (data: Array[Array[Double]]): Unit = {
     // Allocate row-major
-    cublasAlloc(data.length * data(0).length * jcuda.Sizeof.DOUBLE,
-      jcuda.Sizeof.DOUBLE, vals)
+    cudaMalloc(vals, data.length * data(0).length * jcuda.Sizeof.DOUBLE)
+
     cudaMemcpy(vals, jcuda.Pointer.to(data.toList.flatten.toArray),
       data.length * data(0).length * jcuda.Sizeof.DOUBLE,
       cudaMemcpyHostToDevice)
@@ -148,7 +128,7 @@ final class DenseRowMatrix {
   }
 
   def close() {
-    cublasFree(vals)
+    cudaFree(vals)
   }
 }
 

--- a/cuda/src/test/scala/org/apache/mahout/cuda/CUDATestSuite.scala
+++ b/cuda/src/test/scala/org/apache/mahout/cuda/CUDATestSuite.scala
@@ -9,7 +9,6 @@ import scala.util.Random
 
 class CUDATestSuite extends FunSuite with Matchers {
 
-
   test("sparse mmul at geometry of 1000 x 1000 %*% 1000 x 1000 density = .2.  5 runs") {
     CUDATestSuite.getAverageTimeSparse(1000, 1000, 1000, .20, 1234L, 3)
   }
@@ -20,9 +19,9 @@ class CUDATestSuite extends FunSuite with Matchers {
     CUDATestSuite.getAverageTimeSparse(1000, 1000, 1000, .002, 1234L, 3)
   }
 
-//  test("dense mmul at geometry of 1000 x 1000 %*% 1000 x 1000"){
-//    CUDATestSuite.getAverageTimeDense(1000, 1000, 1000, 5)
-//  }
+  test("dense mmul at geometry of 1000 x 1000 %*% 1000 x 1000"){
+    CUDATestSuite.getAverageTimeDense(1000, 1000, 1000, 5)
+  }
 
 }
 
@@ -67,7 +66,6 @@ object CUDATestSuite {
     ms = System.currentTimeMillis()
     for (i: Int  <- 1 to nruns) {
       mxCuda = prod(cudaA, cudaB, cudaCtx)
-      //mxCuda = prod(cudaA, cudaB, cudaCtx)
     }
 
     ms = (System.currentTimeMillis() - ms) / nruns
@@ -120,14 +118,13 @@ object CUDATestSuite {
     ms = System.currentTimeMillis()
     for (i: Int  <- 1 to nruns) {
       mxCuda = prod(cudaA, cudaB, cudaCtx)
-      //mxCuda = prod(cudaA, cudaB, cudaCtx)
     }
 
     ms = (System.currentTimeMillis() - ms) / nruns
     print(s"Mahout JCuda dense multiplication time: $ms ms.\n")
 
     // TODO: Ensure that we've been working with the same matrices.
-    assert(((mxC - fromCUDADenseRM(mxCuda)).norm / mxC.nrow / mxC.ncol) < 1e-16)
+    assert(((mxC - fromCudaDenseRM(mxCuda, cudaCtx)).norm / mxC.nrow / mxC.ncol) < 1e-16)
     cudaA.close()
     cudaB.close()
     mxCuda.close()


### PR DESCRIPTION
My recent changes that should enable dense-dense multiplication:

<pre><code>Mahout JVM Sparse multiplication time: 1113 ms.
Mahout JCuda Sparse multiplication time: 7 ms.
- sparse mmul at geometry of 1000 x 1000 %*% 1000 x 1000 density = .2.  5 runs
Mahout JVM Sparse multiplication time: 24 ms.
Mahout JCuda Sparse multiplication time: 1 ms.
- sparse mmul at geometry of 1000 x 1000 %*% 1000 x 1000 density = .02.  5 runs
Mahout JVM Sparse multiplication time: 0 ms.
Mahout JCuda Sparse multiplication time: 0 ms.
- sparse mmul at geometry of 1000 x 1000 %*% 1000 x 1000 density = .002.  5 runs
Mahout JVM Dense multiplication time: 844 ms.
Mahout JCuda dense multiplication time: 1 ms.
- dense mmul at geometry of 1000 x 1000 %*% 1000 x 1000
UserSetCUDATestSuite:
Mahout JVM Sparse multiplication time: 31 ms.
Mahout JCuda Sparse multiplication time: 1 ms.
User Defined sparse mmul at geometry of 1000 x 1000 %*% 1000 x 1000 density = 0.02 3 runs : 1 ms
- User Defined sparse mmul at geometry of 1000 x 1000 %*% 1000 x 1000 density = 0.02 3 runs
Run completed in 12 seconds, 230 milliseconds.
Total number of tests run: 5
Suites: completed 3, aborted 0
Tests: succeeded 5, failed 0, canceled 0, ignored 0, pending 0
All tests passed.
</code></pre>